### PR TITLE
fix: Duplicated press events on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "clap",
  "clap_mangen",
  "copypasta",
- "crossterm",
+ "crossterm 0.25.0",
  "dbus",
  "futures",
  "hexyl",
@@ -479,6 +479,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
 ]
 
 [[package]]
@@ -1015,15 +1031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,8 +1138,7 @@ checksum = "ce841e0486e7c2412c3740168ede33adeba8e154a15107b879d8162d77c7174e"
 dependencies = [
  "bitflags 1.3.2",
  "cassowary",
- "crossterm",
- "time 0.3.22",
+ "crossterm 0.26.1",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1419,8 +1425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ byteorder = "1.4.3"
 chrono = "0.4.26"
 clap = { version = "4.3.4", features = ["derive"] }
 copypasta = "0.8.2"
-crossterm = "0.26.1"
+crossterm = "0.25.0"
 futures = "0.3.28"
 hexyl = "0.13.0"
 lazy_static = "1.4.0"
@@ -27,7 +27,7 @@ regex = "1.8.4"
 tokio = { version = "1.28", features = ["full", "tracing"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
-tui = { package = "ratatui", version = "0.21.0", features = ["all-widgets"] }
+tui = { package = "ratatui", version = "0.21.0" }
 uuid = "1.3.4"
 
 [build-dependencies]

--- a/src/tui/peripheral_view.rs
+++ b/src/tui/peripheral_view.rs
@@ -1,4 +1,3 @@
-use btleplug::api::Peripheral;
 use crossterm::event::KeyCode;
 use regex::Regex;
 use tui::{


### PR DESCRIPTION
According to https://github.com/crossterm-rs/crossterm/issues/752 this issues comes from the latest crossterm so trying to downgrade to the 0.25.0 which looks like doesn't have this issue on winodws 