### PR TITLE
feat: sort the peripherals list

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use clap::CommandFactory;
 
 #[path = "src/cli_args.rs"]
+#[allow(dead_code)]
 mod cli_args;
 
 fn main() -> std::io::Result<()> {

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -215,7 +215,9 @@ pub async fn start_scan(context: Arc<Ctx>) -> Result<()> {
             })
             .collect::<Vec<_>>();
 
-        peripherals.sort_by(|p1, p2| (&p1.name, p1.address).cmp(&(&p2.name, p2.address)));
+        if *context.sort_by_name.lock().unwrap() {
+            peripherals.sort_by(|p1, p2| (&p1.name, p1.address).cmp(&(&p2.name, p2.address)));
+        }
 
         context.latest_scan.write()?.replace(BleScan {
             peripherals,

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -170,7 +170,7 @@ pub async fn start_scan(context: Arc<Ctx>) -> Result<()> {
             .map(Peripheral::properties)
             .collect::<Vec<_>>();
 
-        let peripherals = try_join_all(properties_futures)
+        let mut peripherals = try_join_all(properties_futures)
             .await?
             .into_iter()
             .zip(peripherals.into_iter())
@@ -214,6 +214,8 @@ pub async fn start_scan(context: Arc<Ctx>) -> Result<()> {
                 })
             })
             .collect::<Vec<_>>();
+
+        peripherals.sort_by(|p1, p2| (&p1.name, p1.address).cmp(&(&p2.name, p2.address)));
 
         context.latest_scan.write()?.replace(BleScan {
             peripherals,

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -109,4 +109,8 @@ pub struct Args {
     /// ```
     #[clap(long, value_parser = clap::builder::ValueParser::new(parse_name_map))]
     pub names_map_file: Option<HashMap<uuid::Uuid, String>>,
+
+    /// Sort peripherals by name
+    #[clap(long)]
+    pub sort_by_name: bool,
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -73,12 +73,22 @@ pub enum GeneralSort {
     DefaultSort,
 }
 
+impl GeneralSort {
+    pub fn sort<T: GeneralSortable>(&self, data: &mut [T]) {
+        let should_sort = T::AVAILABLE_SORTS.contains(&self);
+
+        if should_sort {
+            data.sort_by(|a, b| a.cmp(self, a, b));
+        }
+    }
+}
+
 pub trait GeneralSortable {
+    const AVAILABLE_SORTS: &'static [GeneralSort];
     fn cmp(&self, sort: &GeneralSort, a: &Self, b: &Self) -> std::cmp::Ordering;
 }
 
 impl GeneralSort {
-    #[allow(dead_code)] // ? It is actually used in the code, some clippy bug
     pub fn apply_sort<T: GeneralSortable>(&self, a: &T, b: &T) -> std::cmp::Ordering {
         a.cmp(self, a, b)
     }

--- a/src/general_options.rs
+++ b/src/general_options.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use cli_args::GeneralSort;
+use crossterm::event::KeyCode;
+
+use crate::{
+    cli_args::{self, Args},
+    Ctx,
+};
+
+#[derive(Default, Debug)]
+pub struct GeneralOptions {
+    pub sort: GeneralSort,
+}
+
+impl GeneralOptions {
+    pub fn new(args: &Args) -> Self {
+        Self {
+            sort: args.sort.unwrap_or_default(),
+        }
+    }
+
+    pub fn handle_keystroke(keycode: &KeyCode, ctx: &Arc<Ctx>) -> bool {
+        match keycode {
+            KeyCode::Char('n') => {
+                let mut general_options = ctx.general_options.write().unwrap();
+                general_options.sort = match general_options.sort {
+                    GeneralSort::Name => GeneralSort::DefaultSort,
+                    GeneralSort::DefaultSort => GeneralSort::Name,
+                };
+
+                return true;
+            }
+            _ => false,
+        }
+    }
+}

--- a/src/general_options.rs
+++ b/src/general_options.rs
@@ -29,7 +29,7 @@ impl GeneralOptions {
                     GeneralSort::DefaultSort => GeneralSort::Name,
                 };
 
-                return true;
+                true
             }
             _ => false,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ impl Ctx {
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
+    let sort_by_name = args.sort_by_name;
     let ctx = Arc::new(Ctx {
         args,
         latest_scan: RwLock::new(None),
@@ -47,7 +48,7 @@ async fn main() {
             .expect("Can not establish BLE connection."),
         request_scan_restart: Mutex::new(false),
         global_error: Mutex::new(None),
-        sort_by_name: Mutex::new(false),
+        sort_by_name: Mutex::new(sort_by_name),
     });
 
     let ctx_clone = Arc::clone(&ctx);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ pub struct Ctx {
     active_side_effect_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     request_scan_restart: Mutex<bool>,
     global_error: Mutex<Option<crate::error::Error>>,
+    sort_by_name: Mutex<bool>,
 }
 
 impl Ctx {
@@ -46,6 +47,7 @@ async fn main() {
             .expect("Can not establish BLE connection."),
         request_scan_restart: Mutex::new(false),
         global_error: Mutex::new(None),
+        sort_by_name: Mutex::new(false),
     });
 
     let ctx_clone = Arc::clone(&ctx);

--- a/src/tui/connection_view.rs
+++ b/src/tui/connection_view.rs
@@ -331,34 +331,37 @@ impl AppRoute for ConnectionView {
         f.render_widget(paragraph, chunks[0]);
         if chunks[1].height > 0 {
             f.render_widget(
-                block::render_help([
-                    Some(("<-", "Previous value", false)),
-                    Some(("->", "Next value", false)),
-                    Some(("d", "[D]isconnect from device", false)),
-                    Some(("u", "Parse numeric as [u]nsigned", self.unsigned_numbers)),
-                    Some(("f", "Parse numeric as [f]loats", self.float_numbers)),
-                    historical_index.map(|_| {
-                        (
-                            "l",
-                            "Go to the [l]atest values",
-                            self.highlight_copy_char_renders_delay_stack > 0,
-                        )
-                    }),
-                    self.clipboard.as_ref().map(|_| {
-                        (
-                            "c",
-                            "Copy [c]haracteristic UUID",
-                            self.highlight_copy_char_renders_delay_stack > 0,
-                        )
-                    }),
-                    self.clipboard.as_ref().map(|_| {
-                        (
-                            "s",
-                            "Copy [s]ervice UUID",
-                            self.highlight_copy_service_renders_delay_stack > 0,
-                        )
-                    }),
-                ]),
+                block::render_help(
+                    Arc::clone(&self.ctx),
+                    [
+                        Some(("<-", "Previous value", false)),
+                        Some(("->", "Next value", false)),
+                        Some(("d", "[D]isconnect from device", false)),
+                        Some(("u", "Parse numeric as [u]nsigned", self.unsigned_numbers)),
+                        Some(("f", "Parse numeric as [f]loats", self.float_numbers)),
+                        historical_index.map(|_| {
+                            (
+                                "l",
+                                "Go to the [l]atest values",
+                                self.highlight_copy_char_renders_delay_stack > 0,
+                            )
+                        }),
+                        self.clipboard.as_ref().map(|_| {
+                            (
+                                "c",
+                                "Copy [c]haracteristic UUID",
+                                self.highlight_copy_char_renders_delay_stack > 0,
+                            )
+                        }),
+                        self.clipboard.as_ref().map(|_| {
+                            (
+                                "s",
+                                "Copy [s]ervice UUID",
+                                self.highlight_copy_service_renders_delay_stack > 0,
+                            )
+                        }),
+                    ],
+                ),
                 chunks[1],
             );
         }

--- a/src/tui/connection_view.rs
+++ b/src/tui/connection_view.rs
@@ -290,7 +290,7 @@ impl AppRoute for ConnectionView {
 
             use ansi_to_tui::IntoText;
             if let Ok(output) = hexyl_output_buf.into_text() {
-                text.extend(output.into_iter());
+                text.extend(output);
             } else {
                 tracing::error!(
                     ?hexyl_output_buf,

--- a/src/tui/peripheral_list.rs
+++ b/src/tui/peripheral_list.rs
@@ -139,6 +139,10 @@ impl AppRoute for PeripheralList {
                             }
                         }
                         KeyCode::Char('u') => self.to_remove_unknowns = !self.to_remove_unknowns,
+                        KeyCode::Char('s') => {
+                            let mut sort_by_name = self.ctx.sort_by_name.lock().unwrap();
+                            *sort_by_name = !*sort_by_name;
+                        }
                         _ => {}
                     }
                 }
@@ -270,6 +274,7 @@ impl AppRoute for PeripheralList {
                     Some(("u", "Hide unknown devices", self.to_remove_unknowns)),
                     Some(("->", "Connect to device", false)),
                     Some(("r", "Restart scan", false)),
+                    Some(("s", "Sort by name", *self.ctx.sort_by_name.lock().unwrap())),
                     Some(("h/j or arrows", "Navigate", false)),
                 ]),
                 chunks[2],

--- a/src/tui/ui/block.rs
+++ b/src/tui/ui/block.rs
@@ -1,3 +1,5 @@
+use crate::{cli_args, Ctx};
+use std::sync::Arc;
 use tui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -62,12 +64,42 @@ impl<'a, TTitle: Into<Title<'a>> + Default> From<BlendrBlock<'a, TTitle>>
     }
 }
 
-pub fn render_help<const N: usize>(help: [Option<(&str, &str, bool)>; N]) -> impl Widget {
+pub fn render_help<const N: usize>(
+    ctx: Arc<Ctx>,
+    help: [Option<(&str, &str, bool)>; N],
+) -> impl Widget {
+    const SPACING: &str = "    ";
+    let general_options_guard = &ctx.general_options.read();
+    let general_options = general_options_guard.as_ref().unwrap();
+
+    let general_options_spans = [
+        Span::from("Sort by: "),
+        Span::styled(
+            "[n]ame",
+            if general_options.sort == cli_args::GeneralSort::Name {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            },
+        ),
+        Span::from(" | "),
+        Span::styled(
+            "default",
+            if general_options.sort == cli_args::GeneralSort::DefaultSort {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            },
+        ),
+        Span::from(SPACING),
+    ];
+
     let spans: Vec<_> = help
         .into_iter()
         .flatten()
         .map(|(key, text, bold)| {
-            const SPACING: &str = "    ";
             let mut key_span = Span::from(format!("[{key}] {text}{SPACING}"));
 
             if bold {
@@ -79,9 +111,10 @@ pub fn render_help<const N: usize>(help: [Option<(&str, &str, bool)>; N]) -> imp
             // 4 spaces is a good spacing between the two helpers
             key_span
         })
+        .chain(general_options_spans.into_iter())
         .collect();
 
     Paragraph::new(Line::from(spans))
-        .style(Style::default().fg(Color::DarkGray))
+        .style(Style::default().fg(Color::Gray))
         .wrap(Wrap { trim: true })
 }

--- a/src/tui/ui/block.rs
+++ b/src/tui/ui/block.rs
@@ -111,7 +111,7 @@ pub fn render_help<const N: usize>(
             // 4 spaces is a good spacing between the two helpers
             key_span
         })
-        .chain(general_options_spans.into_iter())
+        .chain(general_options_spans)
         .collect();
 
     Paragraph::new(Line::from(spans))

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+ratatui="ratatui"


### PR DESCRIPTION
This prevents the list content to jump around, making it simpler to select a peripheral.

`sort_by` is used instead of `sort_by_key` because it seems not possible to use the latter with `String`s.