### PR TITLE
feat: Display addresses in the peripherals list

### DIFF
--- a/src/tui/peripheral_list.rs
+++ b/src/tui/peripheral_list.rs
@@ -233,9 +233,10 @@ impl AppRoute for PeripheralList {
             .map(|(i, peripheral)| {
                 let is_highlighted = Some(i) == self.list_state.selected();
                 ListItem::new(Span::from(format!(
-                    "{}{}{}",
+                    "{}{} ({}) {}",
                     if is_highlighted { "> " } else { "  " },
                     peripheral.name,
+                    peripheral.address,
                     match peripheral.rssi {
                         Some(rssi) => format!(" (rssi {rssi})"),
                         None => String::from(""),


### PR DESCRIPTION
This is useful when you have multiple devices with the same name or devices without a name.